### PR TITLE
feat: Add GitHub Pages static site deployment

### DIFF
--- a/GITHUB_PAGES_SETUP.md
+++ b/GITHUB_PAGES_SETUP.md
@@ -1,0 +1,120 @@
+# GitHub Pages セットアップガイド
+
+このWordPressテーマを GitHub Pages で静的サイトとして公開するためのセットアップ手順です。
+
+## 🚀 セットアップ手順
+
+### 1. リポジトリ設定
+
+1. **GitHub リポジトリの Settings に移動**
+2. **Pages セクションに移動**
+3. **Source を "GitHub Actions" に設定**
+
+### 2. GitHub Actions ワークフローの確認
+
+`.github/workflows/deploy-pages.yml` ファイルが自動的に作成されており、以下の機能を提供します：
+
+- `main` ブランチへの push 時に自動デプロイ
+- Pull Request でのプレビュー
+- 手動でのデプロイ実行
+
+### 3. 静的ファイル構成
+
+以下の静的HTMLファイルが作成されています：
+
+```
+├── index.html          # メインランディングページ
+├── columns.html        # コラム一覧ページ  
+├── column-sample.html  # サンプルコラム記事
+├── style.css          # メインスタイルシート
+├── assets/
+│   ├── css/
+│   │   └── custom.css # カスタムスタイル
+│   └── js/
+│       ├── main.js    # メインJavaScript
+│       └── smooth-scroll.js # スムーススクロール
+```
+
+## 📝 WordPressテーマからの変更点
+
+### 変換された機能
+
+✅ **完全対応**
+- ランディングページのデザインとレイアウト
+- レスポンシブデザイン
+- Adobe Spectrumデザインシステム
+- スムーススクロールとナビゲーション
+- FAQ アコーディオン機能
+
+✅ **静的化対応**
+- メニューナビゲーション（静的リンクに変更）
+- フッター情報
+- コラムページ構造
+- ソーシャルシェアボタン
+
+### 動的機能の制限
+
+⚠️ **注意：以下の機能は静的サイトでは動作しません**
+- WordPress管理画面での設定変更
+- CTAボタンURL/テキストのカスタマイザー設定
+- 動的なコンテンツ生成
+- データベース連携機能
+- コンタクトフォーム
+- 実際のブログ機能
+
+## 🎨 カスタマイズ方法
+
+### CTAボタンの変更
+`index.html` の以下の部分を編集：
+```html
+<a href="#demo" class="btn btn-primary btn-large">
+    今すぐチェックしてみる
+</a>
+```
+
+### コンテンツの更新
+- `index.html`: メインランディングページ
+- `columns.html`: コラム一覧ページ
+- `column-sample.html`: サンプル記事ページ
+
+### スタイルの変更
+- `style.css`: メインスタイルシート
+- `assets/css/custom.css`: カスタムスタイル
+
+## 🌐 公開URL
+
+デプロイ後、サイトは以下のURLでアクセス可能です：
+```
+https://{username}.github.io/{repository-name}/
+```
+
+## 🔧 トラブルシューティング
+
+### デプロイが失敗する場合
+
+1. **Permissions の確認**
+   - Settings > Actions > General > Workflow permissions
+   - "Read and write permissions" を選択
+
+2. **Pages 設定の確認**  
+   - Settings > Pages > Source が "GitHub Actions" になっているか確認
+
+3. **ワークフローログの確認**
+   - Actions タブでエラーログを確認
+
+### ファイルが見つからない場合
+
+静的サイトではパスの大文字小文字が重要です：
+- `index.html` (ファイル名は小文字)
+- リンクパスも正確に記述する
+
+## 📞 サポート
+
+問題が発生した場合は、以下を確認してください：
+1. ブラウザの開発者ツールでエラーログを確認
+2. GitHub Actions のログを確認  
+3. ファイルパスとリンクが正しいか確認
+
+---
+
+**注意**: このセットアップにより、WordPressテーマの見た目と基本機能を GitHub Pages で再現できますが、WordPressの動的機能（管理画面、データベース、プラグイン機能など）は使用できません。

--- a/column-sample.html
+++ b/column-sample.html
@@ -1,0 +1,328 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>AIサマリ対策の基本：検索の新時代への対応方法 - AI Overview LP Theme</title>
+    <meta name="description" content="Google検索にAIサマリが導入された新時代への対応方法を詳しく解説します。">
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="assets/css/custom.css">
+</head>
+<body>
+    
+    <header class="site-header">
+        <nav class="navbar">
+            <div class="container">
+                <div class="navbar-brand">
+                    <a href="index.html" class="site-title">
+                        AI Overview LP Theme
+                    </a>
+                </div>
+                
+                <div class="navbar-menu">
+                    <ul class="nav-menu">
+                        <li><a href="index.html">ホーム</a></li>
+                        <li><a href="index.html#features">機能</a></li>
+                        <li><a href="index.html#benefits">ベネフィット</a></li>
+                        <li><a href="index.html#demo">デモ</a></li>
+                        <li><a href="index.html#faq">FAQ</a></li>
+                        <li><a href="columns.html">コラム</a></li>
+                    </ul>
+                </div>
+                
+                <button class="navbar-toggle" id="navbar-toggle" aria-label="メニューを開く">
+                    <span></span>
+                    <span></span>
+                    <span></span>
+                </button>
+            </div>
+        </nav>
+    </header>
+    
+    <main id="main" class="site-main">
+
+<article class="single-column">
+    
+    <header class="column-header">
+        <div class="container-narrow">
+            <div class="column-categories">
+                <a href="columns.html" class="badge">AI対策</a>
+            </div>
+            
+            <h1 class="column-title">AIサマリ（AI Overview）対策の基本：検索の新時代への対応方法</h1>
+            
+            <div class="column-meta">
+                <div class="meta-item">
+                    <time datetime="2024-12-15">2024年12月15日</time>
+                </div>
+                <div class="meta-item">
+                    <span class="author">by AI Overview Team</span>
+                </div>
+            </div>
+            
+            <div class="column-featured-image">
+                <img src="https://via.placeholder.com/800x400/0073FF/FFFFFF?text=AI+Overview+Guide" alt="AIサマリ対策の基本" class="featured-image">
+            </div>
+        </div>
+    </header>
+    
+    <div class="column-body">
+        <div class="container-narrow">
+            <div class="column-content">
+                <h2>AIサマリとは何か？</h2>
+                <p>Google検索にAIサマリ（AI Overview）が導入されて以来、検索結果の表示方法に大きな変化が起きています。AIサマリとは、検索クエリに対してAIが複数のウェブページから情報を収集し、要約して表示する機能です。</p>
+                
+                <p>従来のSEOでは「検索順位を上げる」ことが主な目的でしたが、AIサマリの登場により、<strong>「AIに拾われやすいコンテンツを作る」</strong>という新しい視点が必要になりました。</p>
+                
+                <h2>なぜAIサマリ対策が重要なのか？</h2>
+                <p>AIサマリが表示される検索結果では、多くのユーザーがその要約内容だけで情報を得て、実際のウェブサイトをクリックしない傾向が見られます。これは以下のような影響をもたらします：</p>
+                
+                <ul>
+                    <li><strong>アクセス数の減少</strong>：検索上位にランクインしてもクリック数が減少</li>
+                    <li><strong>ブランド認知の機会損失</strong>：AIサマリに載らなければ存在を認知されない</li>
+                    <li><strong>競合との差別化困難</strong>：AIが複数サイトの情報を統合するため、独自性が薄れる</li>
+                </ul>
+                
+                <h2>AIサマリに載りやすいコンテンツの特徴</h2>
+                <p>当プラグインの分析結果から、AIサマリに取り上げられやすいコンテンツには以下のような特徴があることが分かりました：</p>
+                
+                <h3>1. 構造化された情報</h3>
+                <p>見出しタグ（H1、H2、H3）を適切に使用し、情報が整理されているコンテンツはAIに理解されやすくなります。</p>
+                
+                <h3>2. 具体的で正確な情報</h3>
+                <p>曖昧な表現よりも、数値や事実に基づく具体的な情報の方が信頼性が高いとAIに判断されます。</p>
+                
+                <h3>3. 質問に対する直接的な回答</h3>
+                <p>検索クエリに対して明確で直接的な回答を提供するコンテンツが優先されます。</p>
+                
+                <h2>実践的なAIサマリ対策手法</h2>
+                
+                <h3>コンテンツ構造の最適化</h3>
+                <p>以下の構造でコンテンツを組み立てることを推奨します：</p>
+                
+                <ol>
+                    <li><strong>導入部分</strong>：検索意図に直接答える要約</li>
+                    <li><strong>詳細説明</strong>：根拠やデータを含む詳しい解説</li>
+                    <li><strong>実践方法</strong>：具体的なステップや手順</li>
+                    <li><strong>まとめ</strong>：重要ポイントの再確認</li>
+                </ol>
+                
+                <h3>キーワード戦略の見直し</h3>
+                <p>従来のSEOキーワードに加えて、以下の要素を考慮する必要があります：</p>
+                
+                <ul>
+                    <li>自然な文章での質問形式キーワード</li>
+                    <li>会話調の検索クエリ</li>
+                    <li>「〜とは」「〜方法」「〜やり方」等の情報検索型クエリ</li>
+                </ul>
+                
+                <h2>当プラグインでできること</h2>
+                <p>私たちのWordPressプラグインでは、これらのAIサマリ対策を自動化・効率化できます：</p>
+                
+                <div class="highlight-box">
+                    <ul>
+                        <li>✓ 記事のAI最適化度を自動チェック</li>
+                        <li>✓ AIサマリ表示率のリアルタイム監視</li>
+                        <li>✓ 改善提案の自動生成</li>
+                        <li>✓ 競合サイトとの比較分析</li>
+                    </ul>
+                </div>
+                
+                <h2>まとめ</h2>
+                <p>AIサマリの登場により、SEOの概念は大きく変化しています。従来の「検索エンジン最適化」から「AI最適化（AIO: AI Optimization）」へとシフトしていく中で、早期に対応することが競合優位性を保つ鍵となります。</p>
+                
+                <p>当プラグインを活用することで、この新しい時代の検索環境に適応し、持続的な成果を上げることができます。</p>
+            </div>
+            
+            <div class="column-tags">
+                <div class="tags-wrapper">
+                    <span class="tags-label">タグ:</span>
+                    <a href="#" class="tag-item">#AIサマリ</a>
+                    <a href="#" class="tag-item">#SEO</a>
+                    <a href="#" class="tag-item">#AI対策</a>
+                    <a href="#" class="tag-item">#コンテンツマーケティング</a>
+                </div>
+            </div>
+            
+            <div class="column-share">
+                <h3>この記事をシェア</h3>
+                <div class="share-buttons">
+                    <a href="https://twitter.com/share?url=&text=AIサマリ対策の基本：検索の新時代への対応方法" 
+                       target="_blank" 
+                       rel="noopener noreferrer" 
+                       class="share-button share-twitter">
+                        Twitter
+                    </a>
+                    <a href="https://www.facebook.com/sharer/sharer.php?u=" 
+                       target="_blank" 
+                       rel="noopener noreferrer" 
+                       class="share-button share-facebook">
+                        Facebook
+                    </a>
+                    <a href="https://www.linkedin.com/shareArticle?mini=true&url=&title=AIサマリ対策の基本：検索の新時代への対応方法" 
+                       target="_blank" 
+                       rel="noopener noreferrer" 
+                       class="share-button share-linkedin">
+                        LinkedIn
+                    </a>
+                </div>
+            </div>
+            
+            <nav class="column-navigation">
+                <div class="nav-previous">
+                    <a href="columns.html">← コラム一覧に戻る</a>
+                </div>
+                <div class="nav-next">
+                    <a href="#">次の記事 →</a>
+                </div>
+            </nav>
+        </div>
+    </div>
+    
+    <section class="related-columns section-gray">
+        <div class="container">
+            <h2 class="section-title text-center">関連記事</h2>
+            <div class="columns-grid grid grid-3">
+                <article class="column-card card">
+                    <div class="column-thumbnail">
+                        <a href="#">
+                            <img src="https://via.placeholder.com/300x200/0073FF/FFFFFF?text=SEO+2025" alt="SEO戦略" class="column-image">
+                        </a>
+                    </div>
+                    
+                    <div class="column-content">
+                        <h3 class="column-title">
+                            <a href="#">2025年のSEO戦略：AIが変える検索の未来</a>
+                        </h3>
+                        
+                        <div class="column-meta">
+                            <time datetime="2024-12-10">2024年12月10日</time>
+                        </div>
+                        
+                        <a href="#" class="read-more-link">
+                            続きを読む →
+                        </a>
+                    </div>
+                </article>
+
+                <article class="column-card card">
+                    <div class="column-thumbnail">
+                        <a href="#">
+                            <img src="https://via.placeholder.com/300x200/0073FF/FFFFFF?text=AI+Content" alt="AIコンテンツ" class="column-image">
+                        </a>
+                    </div>
+                    
+                    <div class="column-content">
+                        <h3 class="column-title">
+                            <a href="#">AIサマリに載りやすいコンテンツの作り方：5つのポイント</a>
+                        </h3>
+                        
+                        <div class="column-meta">
+                            <time datetime="2024-11-20">2024年11月20日</time>
+                        </div>
+                        
+                        <a href="#" class="read-more-link">
+                            続きを読む →
+                        </a>
+                    </div>
+                </article>
+
+                <article class="column-card card">
+                    <div class="column-thumbnail">
+                        <a href="#">
+                            <img src="https://via.placeholder.com/300x200/0073FF/FFFFFF?text=WordPress" alt="WordPressプラグイン" class="column-image">
+                        </a>
+                    </div>
+                    
+                    <div class="column-content">
+                        <h3 class="column-title">
+                            <a href="#">WordPressでAI対策を効率化するプラグインの選び方</a>
+                        </h3>
+                        
+                        <div class="column-meta">
+                            <time datetime="2024-12-05">2024年12月5日</time>
+                        </div>
+                        
+                        <a href="#" class="read-more-link">
+                            続きを読む →
+                        </a>
+                    </div>
+                </article>
+            </div>
+        </div>
+    </section>
+    
+    <section class="column-cta">
+        <div class="container-narrow">
+            <div class="cta-section">
+                <h2>AIサマリ対策を今すぐ始めませんか？</h2>
+                <p>あなたの記事もAI検索に最適化して、より多くのユーザーにリーチしましょう。</p>
+                <a href="index.html#demo" class="btn btn-primary btn-large">
+                    無料デモを試してみる
+                </a>
+            </div>
+        </div>
+    </section>
+    
+</article>
+
+    </main><!-- #main -->
+    
+    <footer class="site-footer">
+        <div class="footer-widgets">
+            <div class="container">
+                <div class="footer-widgets-grid">
+                    <div class="footer-widget-area">
+                        <h4>会社情報</h4>
+                        <ul>
+                            <li><a href="#">会社概要</a></li>
+                            <li><a href="#">お問い合わせ</a></li>
+                            <li><a href="#">プライバシーポリシー</a></li>
+                        </ul>
+                    </div>
+                    
+                    <div class="footer-widget-area">
+                        <h4>サービス</h4>
+                        <ul>
+                            <li><a href="#">プラグイン概要</a></li>
+                            <li><a href="#">料金プラン</a></li>
+                            <li><a href="#">サポート</a></li>
+                        </ul>
+                    </div>
+                    
+                    <div class="footer-widget-area">
+                        <h4>リソース</h4>
+                        <ul>
+                            <li><a href="columns.html">コラム</a></li>
+                            <li><a href="#">ドキュメント</a></li>
+                            <li><a href="#">よくある質問</a></li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+        
+        <div class="footer-bottom">
+            <div class="container">
+                <div class="footer-bottom-content">
+                    <div class="footer-copyright">
+                        <p>&copy; 2025 AI Overview LP Theme. All rights reserved.</p>
+                    </div>
+                    
+                    <div class="footer-menu">
+                        <ul class="footer-nav">
+                            <li><a href="#">利用規約</a></li>
+                            <li><a href="#">プライバシーポリシー</a></li>
+                            <li><a href="#">サイトマップ</a></li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </footer>
+    
+    <script src="assets/js/main.js"></script>
+    <script src="assets/js/smooth-scroll.js"></script>
+</body>
+</html>

--- a/columns.html
+++ b/columns.html
@@ -1,0 +1,313 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>コラム - AI Overview LP Theme</title>
+    <meta name="description" content="AI Overview対策とSEOに関する最新情報をお届けするコラム集">
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="assets/css/custom.css">
+</head>
+<body>
+    
+    <header class="site-header">
+        <nav class="navbar">
+            <div class="container">
+                <div class="navbar-brand">
+                    <a href="index.html" class="site-title">
+                        AI Overview LP Theme
+                    </a>
+                </div>
+                
+                <div class="navbar-menu">
+                    <ul class="nav-menu">
+                        <li><a href="index.html">ホーム</a></li>
+                        <li><a href="#features">機能</a></li>
+                        <li><a href="#benefits">ベネフィット</a></li>
+                        <li><a href="#demo">デモ</a></li>
+                        <li><a href="#faq">FAQ</a></li>
+                        <li><a href="columns.html" class="active">コラム</a></li>
+                    </ul>
+                </div>
+                
+                <button class="navbar-toggle" id="navbar-toggle" aria-label="メニューを開く">
+                    <span></span>
+                    <span></span>
+                    <span></span>
+                </button>
+            </div>
+        </nav>
+    </header>
+    
+    <main id="main" class="site-main">
+
+<section class="column-archive-section">
+    <div class="container">
+        <header class="archive-header">
+            <h1 class="archive-title">コラム</h1>
+            <p class="archive-description">AI Overview対策とSEOに関する最新情報をお届けします</p>
+        </header>
+        
+        <div class="category-filter">
+            <ul class="category-list">
+                <li><a href="columns.html" class="category-item active">すべて</a></li>
+                <li><a href="#" class="category-item">AI対策</a></li>
+                <li><a href="#" class="category-item">SEO基礎</a></li>
+                <li><a href="#" class="category-item">ツール紹介</a></li>
+                <li><a href="#" class="category-item">事例紹介</a></li>
+            </ul>
+        </div>
+        
+        <div class="columns-grid grid grid-3">
+            <article class="column-card card">
+                <div class="column-thumbnail">
+                    <a href="column-sample.html">
+                        <img src="https://via.placeholder.com/300x200/0073FF/FFFFFF?text=AI+Overview" alt="AIサマリ対策の基本" class="column-image">
+                    </a>
+                </div>
+                
+                <div class="column-content">
+                    <div class="column-categories">
+                        <span class="badge">AI対策</span>
+                    </div>
+                    
+                    <h2 class="column-title">
+                        <a href="column-sample.html">AIサマリ（AI Overview）対策の基本：検索の新時代への対応方法</a>
+                    </h2>
+                    
+                    <div class="column-meta">
+                        <time datetime="2024-12-15">2024年12月15日</time>
+                    </div>
+                    
+                    <div class="column-excerpt">
+                        <p>Google検索にAIサマリが導入されて以来、従来のSEO戦略だけでは不十分になりました。この記事では、AIサマリに対応するための基本的な戦略をご紹介します。</p>
+                    </div>
+                    
+                    <a href="column-sample.html" class="read-more-link">
+                        続きを読む →
+                    </a>
+                </div>
+            </article>
+
+            <article class="column-card card">
+                <div class="column-thumbnail">
+                    <a href="#">
+                        <img src="https://via.placeholder.com/300x200/0073FF/FFFFFF?text=SEO+Basics" alt="SEO基礎" class="column-image">
+                    </a>
+                </div>
+                
+                <div class="column-content">
+                    <div class="column-categories">
+                        <span class="badge">SEO基礎</span>
+                    </div>
+                    
+                    <h2 class="column-title">
+                        <a href="#">2025年のSEO戦略：AIが変える検索の未来</a>
+                    </h2>
+                    
+                    <div class="column-meta">
+                        <time datetime="2024-12-10">2024年12月10日</time>
+                    </div>
+                    
+                    <div class="column-excerpt">
+                        <p>検索エンジンの進化と共に、SEO戦略も大きく変化しています。AI技術の発達により、これまでの手法に加えて新しいアプローチが必要です。</p>
+                    </div>
+                    
+                    <a href="#" class="read-more-link">
+                        続きを読む →
+                    </a>
+                </div>
+            </article>
+
+            <article class="column-card card">
+                <div class="column-thumbnail">
+                    <a href="#">
+                        <img src="https://via.placeholder.com/300x200/0073FF/FFFFFF?text=Tool+Guide" alt="ツール紹介" class="column-image">
+                    </a>
+                </div>
+                
+                <div class="column-content">
+                    <div class="column-categories">
+                        <span class="badge">ツール紹介</span>
+                    </div>
+                    
+                    <h2 class="column-title">
+                        <a href="#">WordPressでAI対策を効率化するプラグインの選び方</a>
+                    </h2>
+                    
+                    <div class="column-meta">
+                        <time datetime="2024-12-05">2024年12月5日</time>
+                    </div>
+                    
+                    <div class="column-excerpt">
+                        <p>WordPressサイトでAI検索対策を行うためのプラグインを厳選してご紹介。導入から設定まで、初心者でも分かりやすく解説します。</p>
+                    </div>
+                    
+                    <a href="#" class="read-more-link">
+                        続きを読む →
+                    </a>
+                </div>
+            </article>
+
+            <article class="column-card card">
+                <div class="column-thumbnail">
+                    <a href="#">
+                        <img src="https://via.placeholder.com/300x200/0073FF/FFFFFF?text=Case+Study" alt="事例紹介" class="column-image">
+                    </a>
+                </div>
+                
+                <div class="column-content">
+                    <div class="column-categories">
+                        <span class="badge">事例紹介</span>
+                    </div>
+                    
+                    <h2 class="column-title">
+                        <a href="#">成功事例：ECサイトがAI対策でアクセス数を30%改善した方法</a>
+                    </h2>
+                    
+                    <div class="column-meta">
+                        <time datetime="2024-11-28">2024年11月28日</time>
+                    </div>
+                    
+                    <div class="column-excerpt">
+                        <p>とあるECサイトがAI Overview対策により、検索からのアクセス数を大幅に改善した実例をご紹介。具体的な施策と結果を詳しく解説します。</p>
+                    </div>
+                    
+                    <a href="#" class="read-more-link">
+                        続きを読む →
+                    </a>
+                </div>
+            </article>
+
+            <article class="column-card card">
+                <div class="column-thumbnail">
+                    <a href="#">
+                        <img src="https://via.placeholder.com/300x200/0073FF/FFFFFF?text=AI+Tips" alt="AI対策" class="column-image">
+                    </a>
+                </div>
+                
+                <div class="column-content">
+                    <div class="column-categories">
+                        <span class="badge">AI対策</span>
+                    </div>
+                    
+                    <h2 class="column-title">
+                        <a href="#">AIサマリに載りやすいコンテンツの作り方：5つのポイント</a>
+                    </h2>
+                    
+                    <div class="column-meta">
+                        <time datetime="2024-11-20">2024年11月20日</time>
+                    </div>
+                    
+                    <div class="column-excerpt">
+                        <p>AIサマリに取り上げられやすいコンテンツには共通する特徴があります。この記事では、効果的なコンテンツ作成のための5つのポイントを解説します。</p>
+                    </div>
+                    
+                    <a href="#" class="read-more-link">
+                        続きを読む →
+                    </a>
+                </div>
+            </article>
+
+            <article class="column-card card">
+                <div class="column-thumbnail">
+                    <a href="#">
+                        <img src="https://via.placeholder.com/300x200/0073FF/FFFFFF?text=SEO+Update" alt="SEO基礎" class="column-image">
+                    </a>
+                </div>
+                
+                <div class="column-content">
+                    <div class="column-categories">
+                        <span class="badge">SEO基礎</span>
+                    </div>
+                    
+                    <h2 class="column-title">
+                        <a href="#">Google検索アルゴリズムの最新アップデート解説</a>
+                    </h2>
+                    
+                    <div class="column-meta">
+                        <time datetime="2024-11-15">2024年11月15日</time>
+                    </div>
+                    
+                    <div class="column-excerpt">
+                        <p>Googleの検索アルゴリズムは常に進化し続けています。最新のアップデート内容と、それに対応するための具体的な対策方法をまとめました。</p>
+                    </div>
+                    
+                    <a href="#" class="read-more-link">
+                        続きを読む →
+                    </a>
+                </div>
+            </article>
+        </div>
+        
+        <div class="pagination">
+            <div class="pagination-links">
+                <span class="page-numbers current">1</span>
+                <a href="#" class="page-numbers">2</a>
+                <a href="#" class="page-numbers">3</a>
+                <a href="#" class="page-numbers next">次へ →</a>
+            </div>
+        </div>
+    </div>
+</section>
+
+    </main><!-- #main -->
+    
+    <footer class="site-footer">
+        <div class="footer-widgets">
+            <div class="container">
+                <div class="footer-widgets-grid">
+                    <div class="footer-widget-area">
+                        <h4>会社情報</h4>
+                        <ul>
+                            <li><a href="#">会社概要</a></li>
+                            <li><a href="#">お問い合わせ</a></li>
+                            <li><a href="#">プライバシーポリシー</a></li>
+                        </ul>
+                    </div>
+                    
+                    <div class="footer-widget-area">
+                        <h4>サービス</h4>
+                        <ul>
+                            <li><a href="#">プラグイン概要</a></li>
+                            <li><a href="#">料金プラン</a></li>
+                            <li><a href="#">サポート</a></li>
+                        </ul>
+                    </div>
+                    
+                    <div class="footer-widget-area">
+                        <h4>リソース</h4>
+                        <ul>
+                            <li><a href="columns.html">コラム</a></li>
+                            <li><a href="#">ドキュメント</a></li>
+                            <li><a href="#">よくある質問</a></li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+        
+        <div class="footer-bottom">
+            <div class="container">
+                <div class="footer-bottom-content">
+                    <div class="footer-copyright">
+                        <p>&copy; 2025 AI Overview LP Theme. All rights reserved.</p>
+                    </div>
+                    
+                    <div class="footer-menu">
+                        <ul class="footer-nav">
+                            <li><a href="#">利用規約</a></li>
+                            <li><a href="#">プライバシーポリシー</a></li>
+                            <li><a href="#">サイトマップ</a></li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </footer>
+    
+    <script src="assets/js/main.js"></script>
+    <script src="assets/js/smooth-scroll.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,355 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>AI Overview LP Theme - Google検索の新時代</title>
+    <meta name="description" content="AI検索対策プラグインのランディングページ。AIサマリに対応する最速のWordPressプラグイン。">
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="assets/css/custom.css">
+</head>
+<body>
+    
+    <header class="site-header">
+        <nav class="navbar">
+            <div class="container">
+                <div class="navbar-brand">
+                    <a href="#" class="site-title">
+                        AI Overview LP Theme
+                    </a>
+                </div>
+                
+                <div class="navbar-menu">
+                    <ul class="nav-menu">
+                        <li><a href="#home">ホーム</a></li>
+                        <li><a href="#features">機能</a></li>
+                        <li><a href="#benefits">ベネフィット</a></li>
+                        <li><a href="#demo">デモ</a></li>
+                        <li><a href="#faq">FAQ</a></li>
+                    </ul>
+                </div>
+                
+                <button class="navbar-toggle" id="navbar-toggle" aria-label="メニューを開く">
+                    <span></span>
+                    <span></span>
+                    <span></span>
+                </button>
+            </div>
+        </nav>
+    </header>
+    
+    <main id="main" class="site-main">
+
+<!-- ファーストビュー -->
+<section class="section-hero" id="home">
+    <div class="container">
+        <div class="hero-content">
+            <h1 class="hero-title">Google検索の新時代<br>あなたのサイトはAIサマリに載っていますか？</h1>
+            <p class="hero-subtitle">SEOだけでは足りない時代。AI検索での存在感を、今すぐ確保。</p>
+            <div class="hero-cta">
+                <a href="#demo" class="btn btn-primary btn-large">
+                    今すぐチェックしてみる
+                </a>
+                <p class="cta-note">無料デモ利用できます</p>
+            </div>
+        </div>
+    </div>
+</section>
+
+<!-- 問題提起 -->
+<section class="section-problem">
+    <div class="container-narrow">
+        <h2 class="section-title text-center">従来のSEOだけでは、もう勝てない時代へ</h2>
+        <div class="problem-content">
+            <p>これまでのSEOは「検索順位を上げる」ことが目的でした。</p>
+            <p>しかし今、Google検索結果には <strong>AIサマリ（AI Overview）</strong> が登場し、多くのユーザーはその要約だけで情報を得ています。</p>
+            <div class="highlight-box">
+                <p class="highlight-text">つまり、どんなに上位表示されても<br><span class="text-danger">AIサマリに取り上げられなければ、クリックされない。</span></p>
+            </div>
+            <p>SEOに投資してきた企業やブロガーにとって、見過ごせない変化が起きています。</p>
+        </div>
+    </div>
+</section>
+
+<!-- 解決策 -->
+<section class="section-solution section-gray" id="features">
+    <div class="container-narrow">
+        <h2 class="section-title text-center">AIサマリに対応する、最速のWordPressプラグイン</h2>
+        <div class="solution-content">
+            <p class="lead text-center">私たちのプラグインは、GoogleのAIサマリに拾われやすい記事作成をサポートします。</p>
+            
+            <div class="features-list">
+                <div class="feature-item">
+                    <div class="feature-icon">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/>
+                        </svg>
+                    </div>
+                    <div class="feature-content">
+                        <h3>自動チェック機能</h3>
+                        <p>投稿記事がAIサマリに最適化されているかを自動チェック</p>
+                    </div>
+                </div>
+                
+                <div class="feature-item">
+                    <div class="feature-icon">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z"/>
+                        </svg>
+                    </div>
+                    <div class="feature-content">
+                        <h3>表示率の可視化</h3>
+                        <p>AIサマリへの表示率をログ化し、数値で把握</p>
+                    </div>
+                </div>
+                
+                <div class="feature-item">
+                    <div class="feature-icon">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z"/>
+                        </svg>
+                    </div>
+                    <div class="feature-content">
+                        <h3>改善提案機能</h3>
+                        <p>改善提案をその場で確認可能</p>
+                    </div>
+                </div>
+            </div>
+            
+            <p class="solution-footer text-center">難しい知識や外注は不要。<br>これからのWeb集客に必須の「AIO対策」を、誰でも簡単に始められます。</p>
+        </div>
+    </div>
+</section>
+
+<!-- ベネフィット -->
+<section class="section-benefits" id="benefits">
+    <div class="container">
+        <h2 class="section-title text-center">導入すれば、こんな未来が手に入ります</h2>
+        <div class="benefits-grid grid grid-3">
+            <div class="benefit-card card">
+                <div class="benefit-icon">
+                    <svg width="48" height="48" viewBox="0 0 24 24" fill="var(--spectrum-blue-600)">
+                        <path d="M23 12l-2.44-2.78.34-3.68-3.61-.82-1.89-3.18L12 3 8.6 1.54 6.71 4.72l-3.61.81.34 3.68L1 12l2.44 2.78-.34 3.69 3.61.82 1.89 3.18L12 21l3.4 1.46 1.89-3.18 3.61-.82-.34-3.68L23 12z"/>
+                    </svg>
+                </div>
+                <h3>アクセス減少を食い止める</h3>
+                <p>SEO流入の減少をAIサマリ経由で補い、サイト露出を維持。</p>
+            </div>
+            
+            <div class="benefit-card card">
+                <div class="benefit-icon">
+                    <svg width="48" height="48" viewBox="0 0 24 24" fill="var(--spectrum-blue-600)">
+                        <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
+                    </svg>
+                </div>
+                <h3>新しい検索体験での集客を確保</h3>
+                <p>AIサマリに載れば、クリックなしでもブランド認知と信頼を獲得。</p>
+            </div>
+            
+            <div class="benefit-card card">
+                <div class="benefit-icon">
+                    <svg width="48" height="48" viewBox="0 0 24 24" fill="var(--spectrum-blue-600)">
+                        <path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z"/>
+                    </svg>
+                </div>
+                <h3>数値で成果を実感できる</h3>
+                <p>AIサマリ表示率をダッシュボードで確認し、改善効果を定量的に把握。</p>
+            </div>
+        </div>
+    </div>
+</section>
+
+<!-- 導入フロー -->
+<section class="section-flow section-gray">
+    <div class="container-narrow">
+        <h2 class="section-title text-center">始め方は、たったの3ステップ</h2>
+        <div class="steps">
+            <div class="step-item">
+                <h3>プラグインをインストール（数分で完了）</h3>
+                <p>WordPressの管理画面から簡単にインストールできます。</p>
+            </div>
+            
+            <div class="step-item">
+                <h3>投稿記事を作成（いつも通り）</h3>
+                <p>特別な操作は不要。普段通りに記事を書くだけです。</p>
+            </div>
+            
+            <div class="step-item">
+                <h3>ダッシュボードでAIサマリ表示率をチェック → 改善</h3>
+                <p>リアルタイムで表示率を確認し、提案に従って改善できます。</p>
+            </div>
+        </div>
+        
+        <div class="flow-footer">
+            <p class="text-center">👉 導入直後から、あなたの記事がAIにどう評価されているか「見える化」できます。</p>
+        </div>
+    </div>
+</section>
+
+<!-- デモ利用の誘導 -->
+<section class="section-demo" id="demo">
+    <div class="container-narrow">
+        <div class="cta-section">
+            <h2>まずは無料デモで、変化を実感してください</h2>
+            <p>デモ版では記事数や機能に制限がありますが、AIサマリ表示率の計測と改善提案を体験できます。</p>
+            <p>実際にあなたのサイトがAIにどう扱われているかを、すぐに確認可能。</p>
+            <p>将来の有料プランでは、さらに高度なAI最適化機能を追加予定です。</p>
+            <a href="#demo" class="btn btn-primary btn-large">
+                今すぐチェックしてみる
+            </a>
+        </div>
+    </div>
+</section>
+
+<!-- ユーザーの声 -->
+<section class="section-testimonials section-gray">
+    <div class="container">
+        <h2 class="section-title text-center">導入ユーザーの声</h2>
+        <div class="testimonials-grid grid grid-2">
+            <div class="testimonial-card card">
+                <div class="testimonial-content">
+                    <p>"SEOで上位にいたのにアクセスが減って困っていましたが、このプラグインでAIサマリに表示され、PVが回復しました。"</p>
+                </div>
+                <div class="testimonial-author">
+                    <strong>中小企業Web担当者</strong>
+                </div>
+            </div>
+            
+            <div class="testimonial-card card">
+                <div class="testimonial-content">
+                    <p>"アフィリエイト記事がAIサマリに載るようになり、売上に直結しました。"</p>
+                </div>
+                <div class="testimonial-author">
+                    <strong>個人ブロガー</strong>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<!-- FAQ -->
+<section class="section-faq" id="faq">
+    <div class="container-narrow">
+        <h2 class="section-title text-center">よくある質問</h2>
+        <div class="faq-list">
+            <div class="faq-item">
+                <h3 class="faq-question">Q. AIサマリって何ですか？</h3>
+                <p class="faq-answer">A. Google検索結果に新しく導入された「AIによる要約枠」のことです。従来のSEOとは異なり、AIがページを選んで要約します。</p>
+            </div>
+            
+            <div class="faq-item">
+                <h3 class="faq-question">Q. 導入は難しいですか？</h3>
+                <p class="faq-answer">A. WordPressにプラグインをアップロードするだけ。専門知識は不要です。</p>
+            </div>
+            
+            <div class="faq-item">
+                <h3 class="faq-question">Q. SEO対策とどう違うんですか？</h3>
+                <p class="faq-answer">A. SEOは検索順位を上げる施策ですが、AIO対策は「AIに拾われやすい記事構成」に整える施策です。両方が必要になります。</p>
+            </div>
+            
+            <div class="faq-item">
+                <h3 class="faq-question">Q. 無料デモはどこまで使えますか？</h3>
+                <p class="faq-answer">A. 記事数や機能に制限はありますが、AIサマリ表示率の確認と改善提案を体験できます。</p>
+            </div>
+        </div>
+    </div>
+</section>
+
+<!-- 今後の展望 -->
+<section class="section-future section-gray">
+    <div class="container-narrow">
+        <h2 class="section-title text-center">安心して使い続けられる理由</h2>
+        <div class="future-points">
+            <div class="future-item">
+                <div class="future-icon">✓</div>
+                <p>ユーザーフィードバックを基に機能を進化</p>
+            </div>
+            <div class="future-item">
+                <div class="future-icon">✓</div>
+                <p>AI要約最適化・構造化データ対応などを順次追加予定</p>
+            </div>
+            <div class="future-item">
+                <div class="future-icon">✓</div>
+                <p>Githubで開発を公開し、透明性を重視</p>
+            </div>
+        </div>
+    </div>
+</section>
+
+<!-- クロージング -->
+<section class="section-closing">
+    <div class="container-narrow">
+        <div class="closing-content text-center">
+            <h2>SEOからAIOへ。<br>検索の新時代に備えましょう</h2>
+            <p>SEOのルールが変わる今、いち早くAIOに対応できるかどうかが、これからの集客の明暗を分けます。</p>
+            <p><strong>あなたの記事はAIサマリに載っていますか？</strong></p>
+            <p>今すぐ無料デモで確認し、未来の集客戦略を始めてください。</p>
+            <div class="closing-cta">
+                <a href="#demo" class="btn btn-primary btn-large">
+                    今すぐチェックしてみる（無料）
+                </a>
+            </div>
+        </div>
+    </div>
+</section>
+
+    </main><!-- #main -->
+    
+    <footer class="site-footer">
+        <div class="footer-widgets">
+            <div class="container">
+                <div class="footer-widgets-grid">
+                    <div class="footer-widget-area">
+                        <h4>会社情報</h4>
+                        <ul>
+                            <li><a href="#">会社概要</a></li>
+                            <li><a href="#">お問い合わせ</a></li>
+                            <li><a href="#">プライバシーポリシー</a></li>
+                        </ul>
+                    </div>
+                    
+                    <div class="footer-widget-area">
+                        <h4>サービス</h4>
+                        <ul>
+                            <li><a href="#">プラグイン概要</a></li>
+                            <li><a href="#">料金プラン</a></li>
+                            <li><a href="#">サポート</a></li>
+                        </ul>
+                    </div>
+                    
+                    <div class="footer-widget-area">
+                        <h4>リソース</h4>
+                        <ul>
+                            <li><a href="#">ドキュメント</a></li>
+                            <li><a href="#">ブログ</a></li>
+                            <li><a href="#">よくある質問</a></li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+        
+        <div class="footer-bottom">
+            <div class="container">
+                <div class="footer-bottom-content">
+                    <div class="footer-copyright">
+                        <p>&copy; 2025 AI Overview LP Theme. All rights reserved.</p>
+                    </div>
+                    
+                    <div class="footer-menu">
+                        <ul class="footer-nav">
+                            <li><a href="#">利用規約</a></li>
+                            <li><a href="#">プライバシーポリシー</a></li>
+                            <li><a href="#">サイトマップ</a></li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </footer>
+    
+    <script src="assets/js/main.js"></script>
+    <script src="assets/js/smooth-scroll.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Convert WordPress theme to static HTML for GitHub Pages hosting

- Create static HTML version of landing page
- Add blog archive and sample post pages
- Preserve Adobe Spectrum design system
- Include comprehensive setup documentation

Resolves #1

Generated with [Claude Code](https://claude.ai/code)