### PR TITLE
Translate Figma design pattern to Japanese

### DIFF
--- a/pattern4-figma.html
+++ b/pattern4-figma.html
@@ -573,10 +573,10 @@
                 
                 <div class="navbar-menu">
                     <ul class="nav-menu">
-                        <li><a href="#home">Home</a></li>
-                        <li><a href="#features">Features</a></li>
-                        <li><a href="#pricing">Pricing</a></li>
-                        <li><a href="#demo">Demo</a></li>
+                        <li><a href="#home">ホーム</a></li>
+                        <li><a href="#features">機能</a></li>
+                        <li><a href="#pricing">料金</a></li>
+                        <li><a href="#demo">デモ</a></li>
                     </ul>
                 </div>
                 
@@ -596,21 +596,21 @@
             <div class="container">
                 <div class="figma-hero-content">
                     <div class="figma-hero-badge">
-                        New: AI Overview Analytics Dashboard
+                        新機能: AI Overview アナリティクス ダッシュボード
                     </div>
                     
                     <h1 class="figma-hero-title">
-                        Design your way to<br>
-                        <span class="gradient-text">AI search success</span>
+                        デザインで実現する<br>
+                        <span class="gradient-text">AI検索成功</span>
                     </h1>
                     
                     <p class="figma-hero-subtitle">
-                        Create, optimize, and scale your content for Google's AI Overview with our comprehensive WordPress plugin designed for modern digital creators.
+                        現代のデジタルクリエイターのために設計された包括的なWordPressプラグインで、GoogleのAI Overviewに対応したコンテンツを作成、最適化、そして拡張しましょう。
                     </p>
                     
                     <div class="figma-button-group">
                         <a href="#demo" class="figma-button figma-button-primary">
-                            <span>Start free trial</span>
+                            <span>無料トライアル開始</span>
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
                                 <path d="M13 7l5 5-5 5M6 12h12"/>
                             </svg>
@@ -619,22 +619,22 @@
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
                                 <path d="M15 10l4.5-4.5M10.5 14l4.5-4.5m0 0l-3.5-3.5m3.5 3.5L19 5.5"/>
                             </svg>
-                            <span>View features</span>
+                            <span>機能を見る</span>
                         </a>
                     </div>
                     
                     <div class="figma-stats">
                         <div class="figma-stat">
                             <span>⚡</span>
-                            <span>98% faster optimization</span>
+                            <span>98%高速最適化</span>
                         </div>
                         <div class="figma-stat">
                             <span>📊</span>
-                            <span>Real-time analytics</span>
+                            <span>リアルタイム分析</span>
                         </div>
                         <div class="figma-stat">
                             <span>🚀</span>
-                            <span>Auto-scaling content</span>
+                            <span>自動スケールコンテンツ</span>
                         </div>
                     </div>
                 </div>
@@ -644,24 +644,24 @@
         <!-- Problem Section -->
         <section class="figma-section">
             <div class="container-narrow">
-                <h2 class="figma-section-title">The search landscape has changed</h2>
+                <h2 class="figma-section-title">検索の風景が変わりました</h2>
                 <p class="figma-section-subtitle">
-                    Traditional SEO strategies are no longer sufficient. Google's AI Overview now dominates search results, 
-                    requiring a completely new approach to content optimization and discovery.
+                    従来のSEO戦略はもはや十分ではありません。GoogleのAI Overviewが検索結果を支配し、
+                    コンテンツ最適化と発見に全く新しいアプローチが必要になっています。
                 </p>
                 
                 <div class="figma-callout">
                     <div class="figma-callout-content">
-                        <h3 class="figma-callout-title">Critical shift happening now</h3>
+                        <h3 class="figma-callout-title">今起こっている重要な変化</h3>
                         <p class="figma-callout-text">
-                            Even top-ranking pages lose significant traffic if they're not featured in AI Overview. 
-                            The future belongs to AI-optimized content strategies.
+                            AI Overviewに取り上げられなければ、上位ランキングページでさえ大幅なトラフィック減少を経験します。
+                            未来はAI最適化されたコンテンツ戦略に属しています。
                         </p>
                     </div>
                 </div>
                 
                 <p class="figma-section-subtitle">
-                    Stay ahead of the curve with tools designed specifically for the AI-first search era.
+                    AIファースト検索時代に特化して設計されたツールで、常に先を行きましょう。
                 </p>
             </div>
         </section>
@@ -669,10 +669,10 @@
         <!-- Features Section -->
         <section class="figma-section figma-section-alt" id="features">
             <div class="container">
-                <h2 class="figma-section-title">Built for creators, by creators</h2>
+                <h2 class="figma-section-title">クリエイターのため、クリエイターによる</h2>
                 <p class="figma-section-subtitle">
-                    Every feature is designed with the modern content creator in mind, providing powerful tools 
-                    that feel intuitive and integrate seamlessly into your existing workflow.
+                    すべての機能は現代のコンテンツクリエイターを念頭に置いて設計され、
+                    直感的でありながら既存のワークフローにシームレスに統合できる強力なツールを提供します。
                 </p>
                 
                 <div class="figma-card-grid">
@@ -684,8 +684,8 @@
                                 </svg>
                             </div>
                             <div class="figma-feature-content">
-                                <h3>Smart Content Analysis</h3>
-                                <p>AI-powered content scanning that identifies optimization opportunities in real-time. Get actionable insights that actually improve your AI Overview visibility.</p>
+                                <h3>スマートコンテンツ分析</h3>
+                                <p>リアルタイムで最適化の機会を特定するAI駆動のコンテンツスキャン。AI Overviewの可視性を実際に向上させる実行可能な洞察を取得します。</p>
                             </div>
                         </div>
                     </div>
@@ -698,8 +698,8 @@
                                 </svg>
                             </div>
                             <div class="figma-feature-content">
-                                <h3>Beautiful Analytics</h3>
-                                <p>Track your AI Overview performance with stunning, easy-to-understand dashboards. Monitor trends, measure impact, and make data-driven decisions.</p>
+                                <h3>美しい分析</h3>
+                                <p>素晴らしく理解しやすいダッシュボードでAI Overviewのパフォーマンスを追跡。トレンドを監視し、インパクトを測定し、データ駆動の意思決定を行います。</p>
                             </div>
                         </div>
                     </div>
@@ -712,8 +712,8 @@
                                 </svg>
                             </div>
                             <div class="figma-feature-content">
-                                <h3>Automated Optimization</h3>
-                                <p>Let our AI handle the technical optimization while you focus on creating great content. Automatic suggestions and one-click improvements.</p>
+                                <h3>自動最適化</h3>
+                                <p>AIが技術的な最適化を処理する間、あなたは素晴らしいコンテンツの作成に集中できます。自動提案とワンクリック改善。</p>
                             </div>
                         </div>
                     </div>
@@ -724,20 +724,20 @@
         <!-- CTA Section -->
         <section class="figma-section" id="demo">
             <div class="container-narrow">
-                <h2 class="figma-section-title">Ready to optimize for AI?</h2>
+                <h2 class="figma-section-title">AI最適化の準備はできましたか？</h2>
                 <p class="figma-section-subtitle">
-                    Start your free 14-day trial today. No credit card required, cancel anytime. 
-                    Join thousands of creators who've already made the switch to AI-optimized content.
+                    今日から14日間の無料トライアルを開始しましょう。クレジットカード不要、いつでもキャンセル可能。
+                    すでにAI最適化コンテンツに切り替えた数千人のクリエイターに参加してください。
                 </p>
                 <div style="text-align: center; margin-top: var(--figma-space-8);">
                     <a href="#demo" class="figma-button figma-button-primary" style="font-size: 16px; padding: var(--figma-space-4) var(--figma-space-8);">
-                        <span>Start your free trial</span>
+                        <span>無料トライアルを開始</span>
                         <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
                             <path d="M13 7l5 5-5 5M6 12h12"/>
                         </svg>
                     </a>
                     <p style="margin-top: var(--figma-space-4); font-size: 14px; color: var(--figma-gray-500);">
-                        ✨ Free trial includes full access to all pro features
+                        ✨ 無料トライアルにはすべてのプロ機能への完全アクセスが含まれます
                     </p>
                 </div>
             </div>
@@ -749,42 +749,42 @@
         <div class="container">
             <div class="figma-footer-grid">
                 <div class="footer-widget-area">
-                    <h4>Product</h4>
+                    <h4>製品</h4>
                     <ul>
-                        <li><a href="#">Features</a></li>
-                        <li><a href="#">Pricing</a></li>
-                        <li><a href="#">Integrations</a></li>
+                        <li><a href="#">機能</a></li>
+                        <li><a href="#">料金</a></li>
+                        <li><a href="#">連携</a></li>
                         <li><a href="#">API</a></li>
                     </ul>
                 </div>
                 
                 <div class="footer-widget-area">
-                    <h4>Resources</h4>
+                    <h4>リソース</h4>
                     <ul>
-                        <li><a href="#">Documentation</a></li>
-                        <li><a href="#">Tutorials</a></li>
-                        <li><a href="#">Case Studies</a></li>
-                        <li><a href="#">Blog</a></li>
+                        <li><a href="#">ドキュメント</a></li>
+                        <li><a href="#">チュートリアル</a></li>
+                        <li><a href="#">ケーススタディ</a></li>
+                        <li><a href="#">ブログ</a></li>
                     </ul>
                 </div>
                 
                 <div class="footer-widget-area">
-                    <h4>Support</h4>
+                    <h4>サポート</h4>
                     <ul>
-                        <li><a href="#">Help Center</a></li>
-                        <li><a href="#">Contact Us</a></li>
-                        <li><a href="#">Community</a></li>
-                        <li><a href="#">Status</a></li>
+                        <li><a href="#">ヘルプセンター</a></li>
+                        <li><a href="#">お問い合わせ</a></li>
+                        <li><a href="#">コミュニティ</a></li>
+                        <li><a href="#">ステータス</a></li>
                     </ul>
                 </div>
                 
                 <div class="footer-widget-area">
-                    <h4>Company</h4>
+                    <h4>会社</h4>
                     <ul>
-                        <li><a href="#">About</a></li>
-                        <li><a href="#">Careers</a></li>
-                        <li><a href="#">Privacy</a></li>
-                        <li><a href="#">Terms</a></li>
+                        <li><a href="#">概要</a></li>
+                        <li><a href="#">採用情報</a></li>
+                        <li><a href="#">プライバシー</a></li>
+                        <li><a href="#">利用規約</a></li>
                     </ul>
                 </div>
             </div>
@@ -792,7 +792,7 @@
         
         <div class="figma-footer-bottom">
             <div class="container">
-                <p>&copy; 2025 AI Overview Studio. Designed with Figma UI2 inspiration.</p>
+                <p>&copy; 2025 AI Overview Studio. Figma UI2インスピレーションでデザイン。</p>
             </div>
         </div>
     </footer>


### PR DESCRIPTION
This PR translates the pattern4-figma.html file from English to Japanese, addressing the user's feedback about the Figma design pattern being in English.

## 🎌 Changes Made

- Translated all English UI elements to Japanese
- Converted navigation menu items (Home → ホーム, Features → 機能, etc.)
- Translated hero section including title and subtitle
- Converted feature descriptions and callout text
- Localized footer section headings and links
- Maintained design system consistency with other patterns

Resolves #5 (comment about Figma page localization)

🤖 Generated with [Claude Code](https://claude.ai/code)